### PR TITLE
Modify example to use espresso-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,10 @@
 # espresso-gradle-example
-Example setup for using TestObject Gradle Plugin with Espresso
 
-    ANDROID_HOME=<path to your android sdk>
-    USERNAME=<username>
-    PASSWORD=<password>
-    APP="basic-espresso-sample"
-    TEST_SUITE=11
+Example setup for using TestObject Gradle Plugin with Espresso. To build the app and test .apk files, run:
 
-    To Execute:
-    $ ./gradlew testobjectUpload
+	./gradlew assemble
+	./gradlew assembleAndroidTest
+	
+The .apk files app-debug.apk and app-debug-androidTest-unaligned.apk will be located in `app/build/outputs/apk/`.
 
-Prerequisites:
-
-1. Login to the test object dashboard and upload an Android application to create the app profile. This can be a placehoder application initially. 
-
-2. Once the app is uploaded click on "Espresso" under the automated testing tab and upload an espresso test .apk file. This can be a placeholder apk file initially. Select a device and run the tests. This will create the Suite ID. 
-
-3. Configure the build.gradle file within the app folder of this project. 
-
-IMPORTANT:  
-
-"username" is what you use for login into testobject, not your email. If you are a member of a team, the root account username is needed to access the storage API. 
-
-"password" must be associated with the correct username
-
-See https://github.com/testobject/testobject-gradle-plugin for more configuration options.
+Tests can be run on the TestObject platform [using the UI](https://wiki.saucelabs.com/display/DOCS/Automated+Testing+on+Real+Devices) or [using Continous Integration](https://wiki.saucelabs.com/display/DOCS/Continuous+Integration+for+Espresso).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,18 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'android'
-apply plugin: 'testobject'
-
-
-testobject {
-    username "$System.env.USERNAME" // the username you use for login into testobject, not your email
-    password "$System.env.PASSWORD" // your password you use for login into testobject
-    //team "foobar" //the name of the team the user belongs to, see nr. 1 in screenshot above,  (optional, if the user is not part of a team)
-    app "$System.env.APP" // name of your app, see nr. 2 in screenshot above
-    testSuite Integer.parseInt("$System.env.TEST_SUITE") // id of your test suite, see nr. 3 in screenshot above
-    runAsPackage false
-}
-
-
 
 android {
     compileSdkVersion 21
@@ -36,13 +23,6 @@ android {
     productFlavors {
     }
 }
-
-
-
-
-
-
-
 
 dependencies {
     // App dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -4,17 +4,11 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
-        maven { url 'http://nexus.testobject.org/nexus/content/repositories/testobject-public-repo' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0'
-        classpath group: 'org.testobject', name: 'testobject-gradle-plugin', version: '0.0.41'
     }
 }
-
-
-
-
 
 allprojects {
     repositories {


### PR DESCRIPTION
With MRDC-292, testobject-gradle-plugin has been deprecated in favor of
espresso-runner.